### PR TITLE
Added logic necessary to allow for a custom close button control to b…

### DIFF
--- a/src/ImageView.js
+++ b/src/ImageView.js
@@ -567,6 +567,10 @@ export default class ImageView extends Component<PropsType, StateType> {
             controls.close = null;
         }
 
+        if (close) {
+            controls.close = close === true ? Close : close;
+        }
+
         if (prev) {
             controls.prev = prev === true ? Prev : prev;
         }


### PR DESCRIPTION
…e passed like prev and next

The variable `close` that is destructured from `this.props.controls` is never checked for being set to anything other than `null` nor given an opportunity to be assigned the `controls` object. Your documentation implies that you should be able to inject a custom component for the close button, so I thought I would take a crack at fixing it. I tested this within my app and it works.