### PR TITLE
imageTranslateValue update with default value to prevent crash

### DIFF
--- a/src/ImageView.js
+++ b/src/ImageView.js
@@ -247,7 +247,8 @@ export default class ImageView extends Component<PropsType, StateType> {
         });
 
         this.imageScaleValue.setValue(scale);
-        this.imageTranslateValue.setValue(translate);
+        this.imageTranslateValue.x.setValue(translate.x || 0);
+        this.imageTranslateValue.y.setValue(translate.y || 0);
     }
 
     // $FlowFixMe


### PR DESCRIPTION
crash error: `AnimatedValue: Attempting to set value to undefined`